### PR TITLE
add google() repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.0.1'


### PR DESCRIPTION
This is required to be able to compile the project outside of Android Studio,
i.e. for F-Droid.

Fixes:
> Could not find com.android.tools.build:gradle:3.0.1.