### PR TITLE
Add fast-scrolling ability

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,4 +18,5 @@ android {
 dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'com.tananaev:adblib:1.2'
+    implementation 'com.l4digital.fastscroll:fastscroll:2.0.1'
 }

--- a/app/src/main/java/com/tananaev/logcat/LineAdapter.java
+++ b/app/src/main/java/com/tananaev/logcat/LineAdapter.java
@@ -31,13 +31,15 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.l4digital.fastscroll.FastScroller;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.LinkedList;
 import java.util.List;
 
-public class LineAdapter extends RecyclerView.Adapter<LineAdapter.LineViewHolder> {
+public class LineAdapter extends RecyclerView.Adapter<LineAdapter.LineViewHolder> implements FastScroller.SectionIndexer {
 
     private List<Line> linesAll = new LinkedList<>();
     private List<Line> linesFiltered = new LinkedList<>();
@@ -246,4 +248,8 @@ public class LineAdapter extends RecyclerView.Adapter<LineAdapter.LineViewHolder
         }
     }
 
+    @Override
+    public CharSequence getSectionText(int position) {
+        return Integer.toString(position);
+    }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,14 +2,17 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.tananaev.logcat.MainActivity">
 
-    <androidx.recyclerview.widget.RecyclerView
+    <com.l4digital.fastscroll.FastScrollRecyclerView
         android:id="@android:id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipToPadding="false" />
+        android:clipToPadding="false"
+        app:bubbleColor="?attr/colorPrimary"
+        app:handleColor="#999999" />
 
 </FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
     <dimen name="space">2dp</dimen>
     <dimen name="margin">8dp</dimen>
     <dimen name="font">12sp</dimen>
+    <dimen name="fastscroll_handle_width">13dp</dimen>
 </resources>


### PR DESCRIPTION
Replace RecyclerView with FastScrollerRecyclerView to offer fast-scrolling through hundreds of thousands of logs quickly without having to manually scroll all the way through (an impossible feat for over 150,000 logs per minute). The bubble letter is "icing on top" and optional (all of the code in LineAdapter can be ignored and the fast-scrolling functionality will remain). The first thing I could come up with for a useful bubble text was the position of the scrollbar in the list. Maybe the time of the log at the scrollbar position would be more useful. What do you think?