### PR TITLE
Modernize Gradle build configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.application'
-    id 'kotlin-android'
+    id 'org.jetbrains.kotlin.android'
     id 'com.google.gms.google-services'
     id 'com.google.firebase.crashlytics'
 }
@@ -13,7 +13,6 @@ android {
         targetSdkVersion 36
         versionCode 17
         versionName "2.3"
-        multiDexEnabled true
     }
     namespace "com.tananaev.logcat"
 
@@ -43,8 +42,6 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'com.android.support:multidex:2.0.1'
     implementation 'com.google.android.material:material:1.12.0'
     implementation 'androidx.core:core-ktx:1.16.0'
     implementation 'com.tananaev:adblib:1.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,6 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
-        android:name="androidx.multidex.MultiDexApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,6 @@
-buildscript {
-    ext.kotlin_version = '2.2.0'
-    repositories {
-        google()
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:8.11.0'
-        classpath 'com.google.gms:google-services:4.4.3'
-        classpath 'com.google.firebase:firebase-crashlytics-gradle:3.0.4'
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
+plugins {
+    id 'com.android.application' version '8.11.0' apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.0' apply false
+    id 'com.google.gms.google-services' version '4.4.3' apply false
+    id 'com.google.firebase.crashlytics' version '3.0.4' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,1 @@
-android.enableJetifier=true
-android.nonFinalResIds=false
-android.nonTransitiveRClass=false
 android.useAndroidX=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,17 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
 include ':app'


### PR DESCRIPTION
## Summary
- Switch root \`build.gradle\` to plugin DSL with \`apply false\`
- Move repositories into \`settings.gradle\` (\`pluginManagement\` + \`dependencyResolutionManagement\`)
- Drop multidex entirely — minSdk 23 enables it automatically, and \`com.android.support:multidex\` was the legacy support-lib version
- Use canonical \`org.jetbrains.kotlin.android\` plugin id instead of the legacy \`kotlin-android\` alias
- Drop explicit \`kotlin-stdlib\` dep — the Kotlin plugin auto-adds it
- Clean up \`gradle.properties\`: drop \`enableJetifier\` (last legacy support-lib dep is gone) and the \`nonTransitiveRClass=false\` / \`nonFinalResIds=false\` overrides that hold back the modern defaults

No dependency version bumps — config modernization only. Java/Kotlin target stays at 17.

## Test plan
- [ ] CI build (\`assembleRegularDebug\`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)