### PR TITLE
Auto-expire release artifacts after one day

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,12 +35,14 @@ jobs:
           name: google-apk
           path: app/build/outputs/apk/google/release/app-google-release.apk
           if-no-files-found: error
+          retention-days: 1
 
       - uses: actions/upload-artifact@v4
         with:
           name: regular-apk
           path: app/build/outputs/apk/regular/release/app-regular-release.apk
           if-no-files-found: error
+          retention-days: 1
 
   smoke-test:
     needs: build


### PR DESCRIPTION
## Summary
- Add \`retention-days: 1\` to the signed APK uploads in the Release workflow so they auto-expire ~24h after a run instead of consuming Actions artifact storage for the default 90 days.
- Smoke-test screenshot keeps the default 90-day retention (tiny, useful for diagnosing past failures).

## Test plan
- [ ] Next tagged release run completes normally and the workflow shows artifacts with 1-day expiration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)